### PR TITLE
Fix configuration ignoring active job queue options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Reason of creation this fork
 This fork was created due to original gem is not supported for long time. 
 
-Will be used to fix issue with dependencies of mime-types gem.
+1. To fix issue with dependencies of mime-types gem.
+2. To fix issue with active_job queue options configuration.
 
 # CarrierWave Backgrounder
 

--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -23,7 +23,13 @@ module CarrierWave
           private
 
           def enqueue_active_job(worker, *args)
-            worker.perform_later(*args.map(&:to_s))
+            # set_options = queue_options.slice(%i[wait wait_until queue priority])
+            # set_options = queue_options.select { |k, v| k.in?(%i[wait wait_until queue priority]) } # slice is 2.5+ Ruby or Rails 3..5.2.3
+            # worker.set(set_options).perform_later(*args.map(&:to_s))
+            # puts worker.methods
+
+            # worker.perform_later(*args.map(&:to_s)) # before
+            worker.set(queue_options).perform_later(*args.map(&:to_s)) # after
           end
 
           def enqueue_delayed_job(worker, *args)

--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -10,10 +10,10 @@ module CarrierWave
         module ClassMethods
           attr_reader :queue_options
 
-          def backend(queue_name=nil, args={})
+          def backend(backend_name=nil, args={})
             return @backend if @backend
             @queue_options = args
-            @backend = queue_name
+            @backend = backend_name
           end
 
           def enqueue_for_backend(worker, class_name, subject_id, mounted_as)
@@ -23,13 +23,7 @@ module CarrierWave
           private
 
           def enqueue_active_job(worker, *args)
-            # set_options = queue_options.slice(%i[wait wait_until queue priority])
-            # set_options = queue_options.select { |k, v| k.in?(%i[wait wait_until queue priority]) } # slice is 2.5+ Ruby or Rails 3..5.2.3
-            # worker.set(set_options).perform_later(*args.map(&:to_s))
-            # puts worker.methods
-
-            # worker.perform_later(*args.map(&:to_s)) # before
-            worker.set(queue_options).perform_later(*args.map(&:to_s)) # after
+            worker.set(queue_options).perform_later(*args.map(&:to_s))
           end
 
           def enqueue_delayed_job(worker, *args)

--- a/spec/backgrounder/support/backends_spec.rb
+++ b/spec/backgrounder/support/backends_spec.rb
@@ -35,9 +35,19 @@ module CarrierWave::Backgrounder
         let(:args) { ['FakeClass', 1, :image] }
 
         it 'invokes perform_later with string arguments' do
-          expect(MockWorker).to receive(:perform_later).with('FakeClass', '1', 'image')
+          expect(MockActiveJob).to receive(:perform_later).with('FakeClass', '1', 'image')
           mock_module.backend :active_job
-          mock_module.enqueue_for_backend(MockWorker, *args)
+          mock_module.enqueue_for_backend(MockActiveJob, *args)
+        end
+
+        context 'queue options configured' do
+          let(:queue_options) { { :queue => :awesome_queue } }
+
+          it 'uses configured queue' do
+            expect(MockActiveJob).to receive(:set).with(queue_options).and_return(MockActiveJob)
+            mock_module.backend :active_job, queue_options
+            mock_module.enqueue_for_backend(MockActiveJob, *args)
+          end
         end
       end
 

--- a/spec/support/backend_constants.rb
+++ b/spec/support/backend_constants.rb
@@ -5,6 +5,17 @@ module GirlFriday
   end
 end
 
+module ActiveJob
+  class Mock
+    def self.set(options = {})
+      self
+    end
+
+    def self.perform_later(*args)
+    end
+  end
+end
+
 module Delayed
   class Job
     def self.column_names

--- a/spec/support/mock_worker.rb
+++ b/spec/support/mock_worker.rb
@@ -20,3 +20,5 @@ class MockNamedSidekiqWorker < MockWorker
   include Sidekiq::Worker
   sidekiq_options queue: :even_better_name
 end
+
+class MockActiveJob < ActiveJob::Mock; end


### PR DESCRIPTION
`queue` config option gets ignored in [this case](https://github.com/lardawge/carrierwave_backgrounder#activejob):
```ruby
CarrierWave::Backgrounder.configure do |c|
  c.backend :active_job, queue: :carrierwave
end
```

---
The only other option to fix the issue is to add `queue_as :carrierwave` to every `ActiveJob` job, which is a mess.