### PR TITLE
Allow ActiveJob workers' queue_as to override global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ class MyActiveJobWorker < ActiveJob::Base
   include ::CarrierWave::Workers::ProcessAssetMixin
   # ... or include ::CarrierWave::Workers::StoreAssetMixin
 
+  queue_as :awesome_queue # will override .configure :queue option, if any
+  # queue_as { 'default' } # use this approach to force `default` queue over .configure :queue option
+
   after_perform do
     # your code here
   end
@@ -163,7 +166,14 @@ end
 Don't forget to set `active_job` as a backend in the config:
 ```ruby
 CarrierWave::Backgrounder.configure do |c|
-  c.backend :active_job, queue: :carrierwave
+  c.backend :active_job
+end
+```
+
+You can also use ActiveJob enqueue options (refer to `ActiveJob::Enqueuing#enqueue`) in global config:
+```ruby
+CarrierWave::Backgrounder.configure do |c|
+  c.backend :active_job, queue: :awesome_queue, wait: 5.minutes, wait_until: Date.tomorrow.midnight
 end
 ```
 

--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -23,7 +23,11 @@ module CarrierWave
           private
 
           def enqueue_active_job(worker, *args)
-            worker.set(queue_options).perform_later(*args.map(&:to_s))
+            set_options = queue_options
+            is_queue_unset = worker.queue_name == 'default' || worker.queue_name.nil?
+            set_options[:queue] = is_queue_unset ? queue_options[:queue] : worker.queue_name
+
+            worker.set(set_options).perform_later(*args.map(&:to_s))
           end
 
           def enqueue_delayed_job(worker, *args)

--- a/spec/backgrounder/support/backends_spec.rb
+++ b/spec/backgrounder/support/backends_spec.rb
@@ -40,13 +40,49 @@ module CarrierWave::Backgrounder
           mock_module.enqueue_for_backend(MockActiveJob, *args)
         end
 
-        context 'queue options configured' do
-          let(:queue_options) { { :queue => :awesome_queue } }
+        describe 'queue name option' do
+          #    config    worker      result
+          #      0         0         'default'
+          #      1         0         config
+          #      1         1         worker (must use a proc for 'default')
+          #      0         1         worker
+          context 'queue name configured globally' do
+            let(:queue_options) { { :queue => :awesome_queue } }
 
-          it 'uses configured queue' do
-            expect(MockActiveJob).to receive(:set).with(queue_options).and_return(MockActiveJob)
-            mock_module.backend :active_job, queue_options
-            mock_module.enqueue_for_backend(MockActiveJob, *args)
+            it 'uses globally configured queue name' do
+              expect(MockActiveJob).to receive(:set).with(queue_options).and_return(MockActiveJob)
+              mock_module.backend :active_job, queue_options
+              mock_module.enqueue_for_backend(MockActiveJob, *args)
+            end
+
+            context 'queue name configured in worker' do
+              it 'uses worker-configured queue' do
+                allow(MockActiveJob).to receive(:queue_name).and_return(:worker_queue)
+
+                expect(MockActiveJob).to receive(:set).with(:queue => :worker_queue).and_return(MockActiveJob)
+                mock_module.backend :active_job, queue_options
+                mock_module.enqueue_for_backend(MockActiveJob, *args)
+              end
+
+              it 'allows to force "default" queue in worker' do
+                default_proc = Proc.new { 'default' }
+                allow(MockActiveJob).to receive(:queue_name).and_return(default_proc)
+
+                expect(MockActiveJob).to receive(:set).with(:queue => default_proc).and_return(MockActiveJob)
+                mock_module.backend :active_job, queue_options
+                mock_module.enqueue_for_backend(MockActiveJob, *args)
+              end
+            end
+          end
+
+          context 'queue name configured per worker' do
+            it 'uses configured queue' do
+              allow(MockActiveJob).to receive(:queue_name).and_return(:awesome_queue)
+
+              expect(MockActiveJob).to receive(:set).with(:queue => :awesome_queue).and_return(MockActiveJob)
+              mock_module.backend :active_job
+              mock_module.enqueue_for_backend(MockActiveJob, *args)
+            end
           end
         end
       end

--- a/spec/support/backend_constants.rb
+++ b/spec/support/backend_constants.rb
@@ -13,6 +13,10 @@ module ActiveJob
 
     def self.perform_later(*args)
     end
+
+    def self.queue_name
+      'default'
+    end
   end
 end
 


### PR DESCRIPTION
This is follow-up fix for the previous #3: per-worker queue configuration should override the global configuration.

As the code checks for `default` queue name, I had to use `ActiveJob`'s option to configure `queue_as` with a block:
```ruby
class SomeWorker < ActiveJob::Base
  queue_as { 'default' }
  # ...
end
```
This way it's possible to override the global configuration with `default` queue, if any worker would require that.